### PR TITLE
Fix typo on templates/upstart.j2

### DIFF
--- a/templates/upstart.j2
+++ b/templates/upstart.j2
@@ -21,7 +21,7 @@ expect daemon
 # The full path to the directory containing the node and forever binaries.
 env NODE_BIN_DIR="{{ forever_node_bin_dir }}"
 # Set the NODE_PATH to the Node.js main node_modules directory.
-env NODE_PATH="{{ forvever_node_path }}"
+env NODE_PATH="{{ forever_node_path }}"
 # The path to the directory where Forever writes files
 env FOREVER_ROOT="{{ forever_root }}"
 # The application startup Javascript file path.


### PR DESCRIPTION
Fix typo on templates/upstart.j2
Line 24, Change forvever_node_path to forever_node_path
