### PR TITLE
Suppress Ansible 2.* warnings about inexplicit with_items

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,12 @@
   file: path={{ forever_root }} state=directory owner={{ forever_user }} mode=0700
 - name: Upstart scripts for Forever managed applications
   template: src=upstart.j2 dest=/etc/init/{{item.name}}.conf owner=root group=root mode=0644
-  with_items: forever_applications
+  with_items: "{{ forever_applications }}"
 - name: Ensure enabled Forever applications are (re)started
   action: service name={{item.name}} state=restarted
-  with_items: forever_applications
+  with_items: "{{ forever_applications }}"
   when: item.enabled|default(True)
 - name: Ensure disabled Forever applications are stopped
   action: service name={{item.name}} state=stopped
-  with_items: forever_applications
+  with_items: "{{ forever_applications }}"
   when: not item.enabled|default(True)


### PR DESCRIPTION
There's an issue similar to this one: https://github.com/ansible/ansible/issues/23496 with new Ansible builds. 

This PR should also be backward compatible.